### PR TITLE
Aggiornati metadati

### DIFF
--- a/index/pubblicare-un-documento.rst
+++ b/index/pubblicare-un-documento.rst
@@ -68,6 +68,8 @@ Metadati del publisher
    +-------------------------+------------------------------------------------------------------------------------------+
    | address                 | L’indirizzo della sede dell’Ente (opzionale)                                             |
    +-------------------------+------------------------------------------------------------------------------------------+
+   | tags                    | La lista dei tag che descrivono il publisher (opzionale)                                 |
+   +-------------------------+------------------------------------------------------------------------------------------+
 
 +--------------------------------------------------------------------+
 | **Esempio. File publisher_settings.yml tratto dallo Starter kit**  |
@@ -76,7 +78,6 @@ Metadati del publisher
 |                                                                    |
 |    publisher:                                                      |
 |      name: Ministero della Documentazione Pubblica                 |
-|      short_name: Min. Doc. Pub.                                    |
 |      description:                                                  |
 |        Lorem ipsum dolor sit amet, consectetur                     |
 |        adipisicing elit, sed do eiusmod tempor                     |
@@ -90,14 +91,14 @@ Metadati del publisher
 |        occaecat cupidatat non proident, sunt in                    |
 |        culpa qui officia deserunt mollit anim id                   |
 |        est laborum.                                                |
-|      website: https://www.ministerodocumentazione.gov.it           |
 |      github_organization_url: https://github.com/organization_name |
+|      short_name: Min. Doc. Pub.                                    |
+|      website: https://www.ministerodocumentazione.gov.it           |
 |      tags:                                                         |
 |        - documents                                                 |
 |        - public                                                    |
 |        - amazing publisher                                         |
-|      assets:                                                       |
-|        logo: assets/images/logo.svg                                |
+|      logo: assets/images/logo.svg                                  |
 |                                                                    |
 +--------------------------------------------------------------------+
 
@@ -128,6 +129,8 @@ Metadati dei progetti
    +---------------+------------------------------------------------------------------------------------------------------------------+
    | end_date      | La data di fine del progetto (opzionale)                                                                         |
    +---------------+------------------------------------------------------------------------------------------------------------------+
+   | tags          | La lista dei tag che descrivono il progetto (opzionale)                                                          |
+   +---------------+------------------------------------------------------------------------------------------------------------------+
 
 +-----------------------------------------------------------------+
 | **Esempio. File projects_setting.yml tratto dallo Starter kit** |
@@ -136,7 +139,6 @@ Metadati dei progetti
 |                                                                 |
 |    projects:                                                    |
 |      - name: Progetto Documentato Pubblicamente                 |
-|        short_name: PDP                                          |
 |        description:                                             |
 |          Lorem ipsum dolor sit amet, consectetur                |
 |          adipisicing elit, sed do eiusmod tempor                |
@@ -150,16 +152,17 @@ Metadati dei progetti
 |          occaecat cupidatat non proident, sunt in               |
 |          culpa qui officia deserunt mollit anim id              |
 |          est laborum.                                           |
-|        website: https://progetto.ministerodocumentazione.gov.it |
-|        tags:                                                    |
-|          - digital                                              |
-|          - citizenship                                          |
-|          - amazing project                                      |
 |        documents:                                               |
 |          - name: Documento del progetto                         |
 |            repository: project-document-doc                     |
 |          - name: Un altro documento del progetto                |
 |            repository: another-project-document-doc             |
+|        short_name: PDP                                          |
+|        website: https://progetto.ministerodocumentazione.gov.it |
+|        tags:                                                    |
+|          - digital                                              |
+|          - citizenship                                          |
+|          - amazing project                                      |
 |                                                                 |
 +-----------------------------------------------------------------+
 

--- a/index/pubblicare-un-documento.rst
+++ b/index/pubblicare-un-documento.rst
@@ -49,25 +49,25 @@ Metadati del publisher
 
 .. table:: Alcuni dei metadati associati al publisher.
 
-   +-------------------------+------------------------------------------------------------------------------+
-   | **Parametro**           | **Descrizione**                                                              |
-   +=========================+==============================================================================+
-   | name                    | Il nome per esteso dell’Ente associato al publisher                          |
-   +-------------------------+------------------------------------------------------------------------------+
-   | short_name              | Il nome abbreviato dell’Ente associato al publisher o l’acronimo (opzionale) |
-   +-------------------------+------------------------------------------------------------------------------+
-   | motto                   | Il motto o una breve frase che contraddistingue l’Ente (opzionale)           |
-   +-------------------------+------------------------------------------------------------------------------+
-   | description             | Una descrizione estesa delle funzioni e degli scopi dell’Ente                |
-   +-------------------------+------------------------------------------------------------------------------+
-   | logo                    | L’URL del logo (può essere contenuto nel repository di configurazione)       |
-   +-------------------------+------------------------------------------------------------------------------+
-   | website                 | L’URL del sito dell’Ente (opzionale)                                         |
-   +-------------------------+------------------------------------------------------------------------------+
-   | address                 | L’indirizzo della sede dell’Ente (opzionale)                                 |
-   +-------------------------+------------------------------------------------------------------------------+
-   | github_organization_url | L’URL del repository dell’organizzazione                                     |
-   +-------------------------+------------------------------------------------------------------------------+
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | **Parametro**           | **Descrizione**                                                                          |
+   +=========================+==========================================================================================+
+   | name                    | Il nome per esteso dell’Ente associato al publisher                                      |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | description             | Una descrizione estesa delle funzioni e degli scopi dell’Ente                            |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | github_organization_url | L’URL del repository dell’organizzazione                                                 |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | short_name              | Il nome abbreviato dell’Ente associato al publisher o l’acronimo (opzionale)             |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | motto                   | Il motto o una breve frase che contraddistingue l’Ente (opzionale)                       |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | logo                    | L’URL del logo (può essere contenuto nel repository di configurazione) (opzionale)       |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | website                 | L’URL del sito dell’Ente (opzionale)                                                     |
+   +-------------------------+------------------------------------------------------------------------------------------+
+   | address                 | L’indirizzo della sede dell’Ente (opzionale)                                             |
+   +-------------------------+------------------------------------------------------------------------------------------+
 
 +--------------------------------------------------------------------+
 | **Esempio. File publisher_settings.yml tratto dallo Starter kit**  |
@@ -114,25 +114,19 @@ Metadati dei progetti
    +===============+==================================================================================================================+
    | name          | Il nome per esteso del progetto                                                                                  |
    +---------------+------------------------------------------------------------------------------------------------------------------+
-   | short_name    | Il nome abbreviato del progetto o l’acronimo (opzionale)                                                         |
-   +---------------+------------------------------------------------------------------------------------------------------------------+
    | description   | Una descrizione estesa delle funzioni e degli scopi del progetto                                                 |
    +---------------+------------------------------------------------------------------------------------------------------------------+
-   | logo          | L’URL del logo (può essere contenuto nel repository di configurazione)                                           |
+   | documents     | La lista dei documenti afferenti al progetto, identificati tramite i nomi dei loro repository                    |
+   +---------------+------------------------------------------------------------------------------------------------------------------+
+   | short_name    | Il nome abbreviato del progetto o l’acronimo (opzionale)                                                         |
+   +---------------+------------------------------------------------------------------------------------------------------------------+
+   | logo          | L’URL del logo (può essere contenuto nel repository di configurazione) (opzionale)                               |
    +---------------+------------------------------------------------------------------------------------------------------------------+
    | website       | L’URL del sito del progetto (opzionale)                                                                          |
    +---------------+------------------------------------------------------------------------------------------------------------------+
    | start_date    | La data di inizio del progetto (opzionale)                                                                       |
    +---------------+------------------------------------------------------------------------------------------------------------------+
    | end_date      | La data di fine del progetto (opzionale)                                                                         |
-   +---------------+------------------------------------------------------------------------------------------------------------------+
-   | documents     | La lista dei documenti collegati al progetto, identificati tramite l’URL del repository del documento associato. |
-   |               |                                                                                                                  |
-   |               | Per ciascun documento, devono essere specificati:                                                                |
-   |               |                                                                                                                  |
-   |               | -  name: il titolo del documento;                                                                                |
-   |               |                                                                                                                  |
-   |               | -  repository: il nome del repository che contiene il documento                                                  |
    +---------------+------------------------------------------------------------------------------------------------------------------+
 
 +-----------------------------------------------------------------+


### PR DESCRIPTION
- Loghi resi opzionali: per i publisher, il layout può sostituirli con dei placeholder se l'utente non li immette, e per i progetti il layout non li prevede.
- Spostati in alto nella tabella le righe dei metadati obbligatori.
- Rimosso il campo `nome` dalla lista dei documenti del singolo progetto: ora è una semplice lista di slug di repository.