### PR TITLE
Fix broken links.

### DIFF
--- a/appendice-2/indice.rst
+++ b/appendice-2/indice.rst
@@ -4,8 +4,8 @@ Indice
 L’indice del documento va inserito nel file index.rst per mezzo della
 direttiva di Sphinx
 `toctree <http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree>`__.
-Per generare la numerazione delle `sezioni <appendice-2/sezioni.html>`__, delle
-`tabelle <appendice-2/tabelle.html>`__ e delle `figure <appendice-2/figure.html>`__, è
+Per generare la numerazione delle `sezioni <sezioni.html>`__, delle
+`tabelle <tabelle.html>`__ e delle `figure <figure.html>`__, è
 necessario usare l’opzione ``:numbered:``. Il contenuto della direttiva è
 costituito da un elenco di tutti i file da includere. I file
 corrispondono alle sezioni di primo livello.

--- a/appendice-2/sezioni.rst
+++ b/appendice-2/sezioni.rst
@@ -2,7 +2,7 @@ Sezioni
 -------
 
 Ciascuna sezione di primo livello (capitolo) corrispondente ad un
-diverso file deve contenere un breve `riassunto <appendice-2.html#struttura-del-documento>`__
+diverso file deve contenere un breve `riassunto <struttura-del-documento.html>`__
 subito dopo il titolo.
 
 Il documento non dovrebbe contenere sezioni oltre il quarto livello.


### PR DESCRIPTION
[Appendice 2/indice](https://docs.italia.it/italia/docs-italia/docs-italia-guide/it/bozza/appendice-2/indice.html) and [Sezioni](https://docs.italia.it/italia/docs-italia/docs-italia-guide/it/bozza/appendice-2/sezioni.html) have broken links in them.

Also, shouldn't we omit the ".html" part in the markup?